### PR TITLE
Integrate dispatch readiness into server health checks

### DIFF
--- a/internal/dispatch/caching/caching.go
+++ b/internal/dispatch/caching/caching.go
@@ -286,3 +286,7 @@ func (cd *Dispatcher) Close() error {
 
 	return nil
 }
+
+func (cd *Dispatcher) Ready() bool {
+	return cd.c != nil && cd.d.Ready()
+}

--- a/internal/dispatch/caching/cachingdispatch_test.go
+++ b/internal/dispatch/caching/cachingdispatch_test.go
@@ -148,3 +148,7 @@ func (ddm delegateDispatchMock) DispatchLookup(ctx context.Context, req *v1.Disp
 func (ddm delegateDispatchMock) Close() error {
 	return nil
 }
+
+func (ddm delegateDispatchMock) Ready() bool {
+	return true
+}

--- a/internal/dispatch/caching/delegate.go
+++ b/internal/dispatch/caching/delegate.go
@@ -11,6 +11,10 @@ const errMessage = "fake delegate should never be called, call SetDelegate on th
 
 type fakeDelegate struct{}
 
+func (fd fakeDelegate) Ready() bool {
+	panic(errMessage)
+}
+
 func (fd fakeDelegate) Close() error {
 	panic(errMessage)
 }

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -23,6 +23,9 @@ type Dispatcher interface {
 
 	// Close closes the dispatcher.
 	Close() error
+
+	// Ready returns true when dispatcher is able to respond to requests
+	Ready() bool
 }
 
 // Check interface describes just the methods required to dispatch check requests.

--- a/internal/dispatch/graph/graph.go
+++ b/internal/dispatch/graph/graph.go
@@ -288,6 +288,10 @@ func (ld *localDispatcher) Close() error {
 	return nil
 }
 
+func (ld *localDispatcher) Ready() bool {
+	return true
+}
+
 func rewriteError(original error) error {
 	nsNotFound := datastore.ErrNamespaceNotFound{}
 

--- a/internal/services/healthcheck_test.go
+++ b/internal/services/healthcheck_test.go
@@ -1,0 +1,65 @@
+//go:build ci
+// +build ci
+
+package services_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/authzed/spicedb/internal/datastore/memdb"
+	tf "github.com/authzed/spicedb/internal/testfixtures"
+	"github.com/authzed/spicedb/internal/testserver"
+	testdatastore "github.com/authzed/spicedb/internal/testserver/datastore"
+	"github.com/authzed/spicedb/internal/testserver/datastore/config"
+	dsconfig "github.com/authzed/spicedb/pkg/cmd/datastore"
+	"github.com/authzed/spicedb/pkg/datastore"
+)
+
+func TestHealthCheck(t *testing.T) {
+	require := require.New(t)
+
+	for _, engine := range datastore.Engines {
+		b := testdatastore.RunDatastoreEngine(t, engine)
+		t.Run(engine, func(t *testing.T) {
+			t.Logf("Running %s health check test", engine)
+			ds := b.NewDatastore(t, config.DatastoreConfigInitFunc(t,
+				dsconfig.WithWatchBufferLength(0),
+				dsconfig.WithGCWindow(time.Duration(90_000_000_000_000)),
+				dsconfig.WithRevisionQuantization(10)))
+			ds, _ = tf.StandardDatastoreWithData(ds, require)
+
+			dispatchConns, cleanup := testserver.TestClusterWithDispatch(t, 2, ds)
+			t.Cleanup(cleanup)
+
+			zerolog.SetGlobalLevel(zerolog.Disabled)
+
+			runHealthChecks(require, dispatchConns[0])
+		})
+	}
+
+	// Check server without dispatching
+	conn, cleanup, _ := testserver.NewTestServer(require, 0, memdb.DisableGC, true, tf.StandardDatastoreWithData)
+	t.Cleanup(cleanup)
+	runHealthChecks(require, conn)
+}
+
+func runHealthChecks(require *require.Assertions, conn *grpc.ClientConn) {
+	hclient := healthpb.NewHealthClient(conn)
+	resp, err := hclient.Check(context.Background(), &healthpb.HealthCheckRequest{Service: v1.SchemaService_ServiceDesc.ServiceName})
+	require.NoError(err)
+	require.Equal(healthpb.HealthCheckResponse_SERVING, resp.GetStatus())
+
+	require.Eventually(func() bool {
+		resp, err = hclient.Check(context.Background(), &healthpb.HealthCheckRequest{Service: v1.PermissionsService_ServiceDesc.ServiceName})
+		require.NoError(err)
+		return healthpb.HealthCheckResponse_SERVING == resp.GetStatus()
+	}, 5*time.Second, 100*time.Millisecond)
+}

--- a/internal/services/server.go
+++ b/internal/services/server.go
@@ -1,10 +1,14 @@
 package services
 
 import (
+	"time"
+
 	v0 "github.com/authzed/authzed-go/proto/authzed/api/v0"
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/authzed/authzed-go/proto/authzed/api/v1alpha1"
 	"github.com/authzed/grpcutil"
+	"github.com/cenkalti/backoff/v4"
+	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
@@ -24,6 +28,9 @@ const (
 
 	// V1SchemaServiceEnabled indicates that the V1 schema service is enabled.
 	V1SchemaServiceEnabled SchemaServiceOption = 1
+
+	// Empty string is used for grpc health check requests for the overall system.
+	OverallServerHealthCheckKey = ""
 )
 
 // RegisterGrpcServices registers all services to be exposed on the GRPC server.
@@ -49,7 +56,7 @@ func RegisterGrpcServices(
 	healthSrv.SetServicesHealthy(&v1alpha1.SchemaService_ServiceDesc)
 
 	v1.RegisterPermissionsServiceServer(srv, v1svc.NewPermissionsServer(dispatch, maxDepth))
-	healthSrv.SetServicesHealthy(&v1.PermissionsService_ServiceDesc)
+	healthSrv.Server.SetServingStatus(v1.PermissionsService_ServiceDesc.ServiceName, healthpb.HealthCheckResponse_NOT_SERVING)
 
 	v1.RegisterWatchServiceServer(srv, v1svc.NewWatchServer())
 	healthSrv.SetServicesHealthy(&v1.WatchService_ServiceDesc)
@@ -62,4 +69,35 @@ func RegisterGrpcServices(
 	healthpb.RegisterHealthServer(srv, healthSrv)
 
 	reflection.Register(grpcutil.NewAuthlessReflectionInterceptor(srv))
+
+	go checkDispatcherServicesReady(dispatch, healthSrv, v1.PermissionsService_ServiceDesc.ServiceName, OverallServerHealthCheckKey)
+}
+
+// checkDispatcherServicesReady waits for the dispatcher to become ready before setting the health check status for the given services
+func checkDispatcherServicesReady(dispatch dispatch.Dispatcher, healthSrv *grpcutil.AuthlessHealthServer, services ...string) {
+	backoffInterval := backoff.NewExponentialBackOff()
+	// Run immediately for the initial check
+	ticker := time.After(0)
+
+	for {
+		_, ok := <-ticker
+		if !ok {
+			log.Warn().Msg("backoff error while waiting for dispatcher health")
+			return
+		}
+
+		if dispatch.Ready() {
+			for _, s := range services {
+				healthSrv.Server.SetServingStatus(s, healthpb.HealthCheckResponse_SERVING)
+			}
+			return
+		}
+
+		nextPush := backoffInterval.NextBackOff()
+		if nextPush == backoff.Stop {
+			log.Warn().Msg("exceed max attempts to check for dispatch ready")
+			return
+		}
+		ticker = time.After(nextPush)
+	}
 }


### PR DESCRIPTION
- Upgrade CI crdb version to 21.2.10
- update newenemy test for datastore v2
- lint e2e directory
- log successful telemetry attempts
- switch telemetry log to debug
- datastore: add a v2 interface
- datastore: update tests for v2 interface
- memdb: add a datastore v2 implementation
- datastore: v2 datastore proxy implementations
- datastore: add a namespace caching proxy
- add preconditions checking helper
- Update call sites for datastore v2 and remove namespace manager.
- datastore: remove NamespaceCacheKey method
- datastore: update common SQL code to support v2
- postgres: convert postgres to datastore v2 API
- crdb: convert to datastore v2 API
- datastore: forward logger through separated context
- spanner: convert to datastore v2 API
- mysql: convert to datstore v2 API
- cmd: default retries to 10, applies to more datastores
- reduce flakiness of newenemy e2e test
- Add dispatch ready, health check integration
