### PR TITLE
Update HTTP api link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Features that distinguish SpiceDB from other systems include:
 
 [gRPC]: https://buf.build/authzed/api/docs/main:authzed.api.v1
 [Zanzibar]: https://authzed.com/blog/what-is-zanzibar/
-[HTTP]: https://app.swaggerhub.com/apis-docs/authzed/authzed/1.0
+[HTTP]: https://www.postman.com/authzed/workspace/spicedb/overview
 [Google's Zanzibar paper]: https://authzed.com/blog/what-is-zanzibar/
 [per-request]: https://docs.authzed.com/reference/api-consistency
 [New Enemy Problem]: https://authzed.com/blog/new-enemies/


### PR DESCRIPTION
- pkg/cmd: add memory percentages for cache sizes
- internal/datastore: set ns cache to be 16MiB
- pkg/cmd: clean up caching
- pkg/cmd: refactor cache defaults into vars
- internal: add test caches
- Add Github wasm build workflow
- Change workflow to run on releases and upload release assets
- pkg/cache: implement metrics for noop cache
- introduce caveat support in WriteRelationships
- Start work for dispatch for caveats by adding MembershipSet
- internal: add docker build tag to transitives
- docker: switch to chainguard base images
- Reorganize the dispatch check protos a bit in preparation for using MembershipSet for checks
- Switch check dispatching to use the new MembershipSet
- Bump github.com/aws/aws-sdk-go from 1.44.90 to 1.44.109
- Bump github.com/lib/pq from 1.10.6 to 1.10.7
- Bump mvdan.cc/gofumpt from 0.3.1 to 0.4.0
- Bump go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
- Cherrypick 5b5e7fc867777e8dcd3f94f21dcb165c1cfe4e34
- Update e2e deps
- Cherrypick a178f18604700b82c44ce86771a33c8900492d24
- Cherrypick df461872245757dd84b2716a2646f8467e67288d
- Cherrypick 583ea3c64818d03551bf67805e0f1ba8231e02ef
- Cherrypick d53a47039d70d56374fb60bcc99a0c0caae0d019
- Cherrypick fd8086675cd739e585238b3391e42dba85630028
- Update e2e deps
- Update validate for recent proto change
- Remove manual validation code now that it is being generated
- Change check dispatching to support caveat expr evaluation
- Bump sigs.k8s.io/controller-runtime from 0.12.3 to 0.13.0
- Bump go.uber.org/goleak from 1.1.12 to 1.2.0
- Add caveats flag to disable writing by default on all datastores
- datastore/postgres: write gc logs without context logger
- datastore: remove specific future revision error
- datastore/postgres: write tx and xid, read only tx
- datastore/common: use revisions instead of uint64 for GC progress
- datastore/postgres: change watch API to use new xids
- datastore/postgres: write tx and xid, read only xid
- datastore/postgres: write only xid, drop support for ids
- datastore/postgres: make xid8 type package private
- revamps logging
- improve logging of http/grpc servers
- Implement structured errors for all user facing errors
- temporarily disable async logging
- update to go 1.19.2 to fix vulns
- add ip allowlists example
- add application attributes example
- example: allow if resource was created before subject
- example: time-bound permission
- example: legal-guardian
- fix datastore integration tests not running
- datastore/postgres: change the migrations to use incremental backfill
- datastore/postgres: add a migration phase flag
- datastore/postgres: add code to support various migration phases
- datastore/postgres: test all phases of migration
- datastore/postgres: provide alternate paths for finding the implicitly named pkey
- datastore/postgres: pass migration batch size from the command line
- .github: bump goreleaser, pro
- goreleaser: push linux packages to gemfury
- improve logging for spicedb migrate cmd
- adds caveat support to postgres
- add timeout to datastore docker boot
- change signature of DeleteCaveats to use names
- return revision in ReadCaveatByName
- run Postgres phased tests in parallel
- make Datastore implement CaveatReader/Storer
- introduce ListCaveats method in CaveatReader
- introduce relationship filtering by caveat name
- add missing caveats to migration assumption test
- rn Caveat->CaveatDefinition, Expression->SerializedExpression
- fix calls to logger that are not being sent
- Add benchmark test for a lookup resources call with intersections and exclusions
- Change lookup resources to use batch checking for non-union results
- Add expression statement lint check to catch missing Send or Msg on zerolog statements
- Add zerolog expr statement check to the linter
- update authzed-go with PermissionService reqs /w context
- adds exhaustive testing of CREATE/TOUCH semantics
- store definition proto instead of serialized expression
- add variadic name filter to ListCaveats
- use spicedb logging package
- unwrap error before passing it to zerolog in custom marshallers
- bump to go-grpc-middleware/v2 everywhere
- Tech Debt cleanup: move LogOnError into common datastore package
- internal: store serialized protos in caches
- Add a namespace proxy cache test suite using a real datastore
- Add lexing and parsing for *referencing* caveats in relation definitions
- Add compiler support for the new `with caveat` syntax
- Add schema generator support for the new with syntax
- Change type system to use a Resolver interface for clearer instantiation
- Add validation of caveats as part of the type system validation
- Add full type checking and conversion of caveat parameters
- Drop context from write calls on caveat interface, as it isn't necessary
- Update namespace diffing and schema checking to handle allowed types with caveats
- Lint fix
- Add type checking of caveats used for subjects in relationship updates
- Comment out caveat-based tests until all datastores support them
- Fixes and improvements after rebasing
- Temporarily ignore errors from creating caveats in datastore tests
- Add missing parameter types to caveats test data
- Add min and max validation to caveat type references
- Add additional encoding and type tests
- Rename Caveat to AllowedCaveat in the ns builder package
- Rename AllowedPublicNamespaceWithCaveat
- Add additional namespace diff tests around caveats
- Fix error logging
- Add additional type system validation tests
- Add additional invalid relationship test
- Add missing generator test case
- Add some additional lexer test cases
- fix more instances of zerolog marshall recursion
- test delete caveated rel with RelationTupleUpdate_DELETE
- fix usages of zerolog global logger
- implements "isSubtreeOf" function for maps
- sever namespace read context
- introduce caveat support in CockroachDB
- datastore/postgres: add the snapshot xmin as the fractional part of the datastore revision
- refactor: switch datastore.Revision to a comparable interface everywhere
- e2e: update go.mod and go.sum
- refactor: make the decimal revisions implementation public
- datastore/postgres: add a test for inverted revisions on concurrent transactions
- datasore: test that all datastores serialize revisions compatible with dispatch
- datastore/memdb: drop vestigial revision in snapshot reader
- datastore/postgres: add index to accelerate aggregate xid8 queries
- datastore/postgres: fix gc to only delete data below cleaned transaction xmin
- v1alpha1: re-expose revision hashing functions for downstream software
- implement caveats for spanner
- Add support for defining caveats in schema, and associated type checking of their use
- Fix tests by making ListCaveats always return, even if caveats are disabled
- Remove writing of caveats in non-caveated standard datastore test data
- Change schema compilation to take in a single schema
- Small schema compiler improvements
- Have the validation file loader write caveats found in schema
- Fix comment formatting
- Fix error marshaling
- Change all caveat dispatch tests to use caveats defined in schema
- Change slice to start as nil
- Add some additional set tests
- Fix error marshaling
- Fix typo
- Unexport compileCaveat, since it is only used for testing
- Rename namespacePath in compiler
- Add comment to referencedParameters
- Lint fixes
- Abstract out the common caveat context check
- Add additional tests around caveat deserialization and type checking
- Improve comment on caveats source
- Tidy e2e mod
- include sboms in release
- .github: fix yamllint warnings
- Elide updates of namespaces which have not changed at all
- datastore/postgres: stop casting xid in queries altogether
- Don't return the caveat key in the ObjectDefinitionNames in v1alpha1 WriteSchemaResponse
- Mark devtools gRPC endpoint enabled by default for the serve-devtools command
- Breakout the integration test suite from unit tests
- Breakout datastore tests into a matrix
- refactor: add context to write methods within a datastore transaction
- parallelize consistent hashring test
- improvements to CI
- parallel PSQL tests
- parallel integration tests
- use setup-go caching
- do not cancel all datastore tests if one fails
- some improvements in Postgres caveat implementation
- introduce caveat support in MySQL
- fixes caching of loop variable in the wrong place
- internal/datastore: add observable proxy
- pkg/cmd: observe caching datastore
- internal/datastore: separating context proxy
- Update authzed-go for the additional validation rules
- Update golang.org/x/text to fix reported CVE
- specifies cache-dependency-path to prevent poisoning
- pg: move column defaults to backfill migration
- do not run CRDB migration in transaction
- Change experimental caveats flag to be handled at the service level
- datastore: DeleteNamespace => DeleteNamespaces
- Add shorter timeouts and better config to gRPC dialing in tests
- Bump go.buf.build/protocolbuffers/go/prometheus/prometheus
- Bump google.golang.org/grpc from 1.49.0 to 1.50.1
- Bump github.com/go-co-op/gocron from 1.17.0 to 1.17.1
- Cherrypick aa5a880247a9e3af56d0787d9e19abdce96296b0
- Tidy e2e after updates
- goreleaser: revert SBOMs
- goreleaser: fix version passed to linker
- .github: update Go version
- also prevent poisoning in build
- do not cache protobuf
- disable caching in wasm tests
- explicitly document why cache is disabled
- Fix panic in validationfile loader when no schema is specified
- Update BaseSubjectSet to support caveat expressions
- datastore/cache: clear the RWT namespace cache when writing namespaces
- Add goleak checking to all the dispatch tests
- Fix size of the expand channels to prevent goroutines from blocking
- cmd/serve: fix deprecated usage of jaeger
- Change dispatch message format for LookupResources in prep for supporting caveats
- Implement support for caveat tracking in reachable resources
- Move ComputeCheck into its own package and add support for bulk checking
- Change parallel checker to use ComputeBulkCheck
- Add caveats support to LookupResources
- Remove support for the v1alpha1 API
- Refactor schema handling into nicer helper methods
- Fix observable proxy to use the more efficient namespace lookup
- Refactor the datastore testfixtures for better code reuse
- Provide additional capabilities around schema writing
- reduce log noise by not logging out canceled queries
- do not log error if context was cancelled
- return proper gRPC errors on context cancellation and deadline errors
- reduce logging noise
- let potential status.Status errors propagate
- test rewriteError handles context errors
- Fix test flake in loader by sorting the expected tuples
- Add support for caveats in LookupSubjects API
- Add better tracking of flaky validator and make sure to clone tuples for testing
- Fix validating datastore to ensure that ellipsis is the only relation on wildcards
- implement StableNamespaceReadWriteTest with caveats
- re-enable v1 services API test
- Make sure ReadSchema returns caveats as well
- Move all protocol buffer equality checking into testutil
- Move generic utilities into pkg
- Move caveat helper functions for building into the caveats package and add some tests
- Rename membership package to `developmentmembership` to give context on when its used
- Move datasets for dispatch into their own package
- Switch remaining caveat builder functions to use the shared functions
- Fix import ordering after move of util package
- Update e2e mod
- Small builder improvements
- fixes broken docker compose link
- datastore/postgres: remove the compensation code for migration phases
- Abstract the relationship update validation code into its own package
- Have validationloader validate relationship updates as well
- Fix for PG when schema is specified in the db url
- Improve the error message for duplicate rels within a single WriteRelationships call
- Return InvalidArgument if caveats are disabled in WriteRels call
- Add context and default timeout for validationfile loading
- Add len checks to WriteCaveats before attempting to write nothing
- Add datastore test for writing empty array caveats
- Note on running integration tests
- Catch nil values for FoundSubjectsByResourceID map and return as errors
- gracefully terminate HTTP Gateway
- fix cert test hanging indefinitely
- redesign gateway close
- replace dgraph ristretto with outcaste
- Add brief sleeps to fix flaky test on macos
- Return a more descriptive error for watch when not enabled
- Fix memdb to always generate unique revision IDs
- Add custom linter to find usages of specified types where Close() is not immediately synchronously called
- Add new lint check to the GHA linter pass
- Immediately close tuple iterators once we are done working with them
- Fix returning of debug information in Check for intersections and exclusions
- Add trace debugging setting for use in the development API
- Add configurable concurrency limits per dispatch type
- Switch the namespace cache to use estimated costs and no serialization
- internal/datastore: remove unused lock
- Fix the flake in the estimated size test for nsdefs
- Update HTTP api link
